### PR TITLE
fix: correct PATH boundary matching in exportPATH

### DIFF
--- a/exportPATH
+++ b/exportPATH
@@ -3,14 +3,13 @@
 if [ -n "$PATH" ]; then
   old_PATH=$PATH:; PATH=
   while [ -n "$old_PATH" ]; do
-    x=${old_PATH%%:*}       # 获取最左边的条目
-    case $PATH: in
-      *:"$x":*) ;;          # 如果已经在 PATH 中，则忽略
-      *) PATH=$PATH$x:;;    # 否则，添加到 PATH 中
+    x=${old_PATH%%:*}       # Get the leftmost entry
+    case ":$PATH:" in
+      *:"$x":*) ;;          # Already in PATH, skip
+      *) PATH=$PATH$x:;;    # Add to PATH
     esac
-    old_PATH=${old_PATH#*:}  # 删除刚处理过的最左边条目
+    old_PATH=${old_PATH#*:}  # Remove the processed leftmost entry
   done
-  PATH=${PATH%:}            # 删除最后一个冒号
+  PATH=${PATH%:}            # Remove trailing colon
 fi
 export PATH
-


### PR DESCRIPTION
- Fix case statement to use ":$PATH:" instead of $PATH: for proper boundary matching
- Prevents matching failures when PATH is empty or contains single element
- Update comments from Chinese to English for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed PATH entry detection to correctly handle entries at the beginning or end of the PATH variable, improving path resolution accuracy in edge cases.

* **Chores**
  * Updated code comments to English for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->