### PR TITLE
chore(chrome): add script to update chrome local state flags

### DIFF
--- a/update_chrome.sh
+++ b/update_chrome.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+FILE="/Users/will/Library/Application Support/Google/Chrome/Local State"
+
+echo "Closing Chrome..."
+pkill -f "Google Chrome" 2>/dev/null
+sleep 2
+
+echo "Backing up..."
+cp "$FILE" ~/Desktop/Local_State_$(date +%Y%m%d_%H%M).backup
+
+echo "Modifying..."
+
+# 1. Gemini eligibility
+sed -i '' 's/"is_glic_eligible":[[:space:]]*false/"is_glic_eligible":true/g' "$FILE"
+
+# 2. Permanent consistency country
+sed -i '' 's/"variations_permanent_consistency_country":\[\([^,]*\),"[^"]*"\]/"variations_permanent_consistency_country":[\1,"us"]/g' "$FILE"
+
+# 3. Current Variations country
+sed -i '' 's/"variations_country":"[^"]*"/"variations_country":"us"/g' "$FILE"
+
+echo "-----------------------------------"
+echo "Verifying modifications:"
+grep -o '"is_glic_eligible":[^,}]*' "$FILE" | head -n 1
+grep -o '"variations_permanent_consistency_country":\[[^]]*\]' "$FILE" | head -n 1
+grep -o '"variations_country":"[^"]*"' "$FILE" | head -n 1
+echo "-----------------------------------"
+
+echo "Done! Restart Chrome and check chrome://flags"


### PR DESCRIPTION
## Summary
- Added `update_chrome.sh` to automatically modify Chrome's Local State file.
- Replaces any existing country code in `variations_country` and `variations_permanent_consistency_country` with `"us"`.
- Enables `is_glic_eligible`.
- Includes post-modification verification output.
- Uses English for all comments and terminal outputs.

## Test plan
- [x] Run script and verify Chrome Local State is updated correctly.
- [x] Verify regex correctly matches array format for permanent consistency country.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new utility script for updating Chrome configuration settings. The script automatically backs up your Local State file with timestamps, applies configuration updates, and provides verification output before requesting a restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->